### PR TITLE
Added workflow to publish to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,36 @@
+# Based on https://github.com/actions/starter-workflows/blob/main/ci/python-publish.yml
+name: Publish to Pypi
+
+on:
+  release:
+    types: [created]
+
+  push:
+    branches:
+      - '*/fixed-publishing-to-pypi'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: "__token__"
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py sdist
+        twine upload dist/*


### PR DESCRIPTION
With this GitHub Workflow, we can automatically publish to PyPI with
each GitHub release. This makes the releases much easier.