### PR TITLE
Added support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'Development Status :: 5 - Production/Stable', 'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License', 'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8', 'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
     ],
     # yapf: enable
     keywords='lexer regexp regular expression',


### PR DESCRIPTION
We include the Python version 3.9 and 3.10 in the continuous
integration.