### PR TITLE
Upgraded pydocstyle to 6.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=[],
     extras_require={
-        'dev': ['mypy==0.942', 'pylint==2.13.4', 'yapf==0.20.2', 'coverage>=4.5.1,<5', 'pydocstyle>=2.1.1,<3']
+        'dev': ['mypy==0.942', 'pylint==2.13.4', 'yapf==0.20.2', 'coverage>=4.5.1,<5', 'pydocstyle==6.1.1']
     },
     py_modules=['lexery'],
     package_data={"lexery": ["py.typed"]})


### PR DESCRIPTION
We had to upgrade pydocstyle to latest version since we had problems
with adding support for Python 3.10.