### PR TITLE
add recursive rule

### DIFF
--- a/lexery/__init__.py
+++ b/lexery/__init__.py
@@ -12,7 +12,6 @@ __status__ = 'Production'
 
 class Token:
     """Represent a token of a text."""
-
     def __init__(self, identifier: str = '', content: str = '', position: int = -1, lineno: int = -1) -> None:
         """
         Initialize.
@@ -42,8 +41,7 @@ class Token:
 
 class Rule:
     """Define a lexing rule."""
-
-    def __init__(self, identifier: str, pattern: Pattern, next=None) -> None:
+    def __init__(self, identifier: str, pattern: Pattern, next_rule=None) -> None:
         """
         Initialize.
 
@@ -52,15 +50,22 @@ class Rule:
         """
         self.identifier = identifier
         self.pattern = pattern
-        self.next = next
-        
+        self.next_rule = next_rule
+
     def match(self, text, pos, lno):
+        """
+        Match the rules with given text and position.
+
+        :param text: the given texte to match
+        :param pos: position of the text
+        :param lno: line number of the text
+        """
         mtch = self.pattern.match(text, pos)
         ret = []
-        if self.next is not None and mtch is not None:
+        if self.next_rule is not None and mtch is not None:
             pos = 0
-            for r in self.next:
-                another_mtch, another_t = r.match(mtch.group(), pos, 0)
+            for rule in self.next_rule:
+                another_mtch, another_t = rule.match(mtch.group(), pos, 0)
                 if another_mtch:
                     ret.append(another_t)
                     pos += len(another_mtch.group())
@@ -70,8 +75,6 @@ class Rule:
             else:
                 ret = ''
         return mtch, Token(self.identifier, content=ret, position=pos, lineno=lno)
-            
-        
 
 
 NONTAB_RE = re.compile(r'[^\t]')
@@ -79,7 +82,6 @@ NONTAB_RE = re.compile(r'[^\t]')
 
 class Error(Exception):
     """Is raised when no token rule applies."""
-
     def __init__(self, line: str, position: int, lineno: int) -> None:
         """
         Initialize.
@@ -106,7 +108,6 @@ WHITESPACE_RE = re.compile(r'\s')
 
 class _Lexing:
     """Keep state of a single lexing."""
-
     def __init__(self, unmatched_identifier: Optional[str] = None) -> None:
         """
         Initialize.
@@ -128,11 +129,10 @@ class _Lexing:
             assert self.unmatched_identifier is not None
 
             self.tokens[-1].append(
-                Token(
-                    identifier=self.unmatched_identifier,
-                    content=''.join(self._unmatched_accumulator),
-                    position=self._unmatched_pos,
-                    lineno=self._unmatched_lineno))
+                Token(identifier=self.unmatched_identifier,
+                      content=''.join(self._unmatched_accumulator),
+                      position=self._unmatched_pos,
+                      lineno=self._unmatched_lineno))
 
             self._unmatched_accumulator = []
 
@@ -144,11 +144,10 @@ class _Lexing:
             assert self.unmatched_identifier is not None
 
             self.tokens[-1].append(
-                Token(
-                    identifier=self.unmatched_identifier,
-                    content=''.join(self._unmatched_accumulator),
-                    position=self._unmatched_pos,
-                    lineno=self._unmatched_lineno))
+                Token(identifier=self.unmatched_identifier,
+                      content=''.join(self._unmatched_accumulator),
+                      position=self._unmatched_pos,
+                      lineno=self._unmatched_lineno))
 
             self._unmatched_accumulator = []
 
@@ -168,19 +167,19 @@ class _Lexing:
             assert self.unmatched_identifier is not None
 
             self.tokens[-1].append(
-                Token(
-                    identifier=self.unmatched_identifier,
-                    content=''.join(self._unmatched_accumulator),
-                    position=self._unmatched_pos,
-                    lineno=self._unmatched_lineno))
+                Token(identifier=self.unmatched_identifier,
+                      content=''.join(self._unmatched_accumulator),
+                      position=self._unmatched_pos,
+                      lineno=self._unmatched_lineno))
 
             self._unmatched_accumulator = []
 
 
 class Lexer:
     """Lex the text given the rules table."""
-
-    def __init__(self, rules: List[Rule], skip_whitespace: bool = False,
+    def __init__(self,
+                 rules: List[Rule],
+                 skip_whitespace: bool = False,
                  unmatched_identifier: Optional[str] = None) -> None:
         """
         Initialize.

--- a/lexery/__init__.py
+++ b/lexery/__init__.py
@@ -210,10 +210,10 @@ class Lexer:
             while position < len(line):
                 mtched = False
                 for rule in self.rules:
-                    _line = line
-                    mtch, _token = rule.match(_line, position, lineno)
+                    another_line = line
+                    mtch, another_token = rule.match(another_line, position, lineno)
                     if mtch:
-                        token = _token
+                        token = another_token
                         lexing.emit_matched_token(token=token)
 
                         position = mtch.end()

--- a/lexery/__init__.py
+++ b/lexery/__init__.py
@@ -43,7 +43,7 @@ class Token:
 class Rule:
     """Define a lexing rule."""
 
-    def __init__(self, identifier: str, pattern: Pattern) -> None:
+    def __init__(self, identifier: str, pattern: Pattern, next=None) -> None:
         """
         Initialize.
 
@@ -52,6 +52,26 @@ class Rule:
         """
         self.identifier = identifier
         self.pattern = pattern
+        self.next = next
+        
+    def match(self, text, pos, lno):
+        mtch = self.pattern.match(text, pos)
+        ret = []
+        if self.next is not None and mtch is not None:
+            pos = 0
+            for r in self.next:
+                _mtch, _t = r.match(mtch.group(), pos, 0)
+                if _mtch:
+                    ret.append(_t)
+                    pos += len(_mtch.group())
+        else:
+            if mtch:
+                ret = mtch.group()
+            else:
+                ret = ''
+        return mtch, Token(self.identifier, content=ret, position=pos, lineno=lno)
+            
+        
 
 
 NONTAB_RE = re.compile(r'[^\t]')
@@ -190,11 +210,10 @@ class Lexer:
             while position < len(line):
                 mtched = False
                 for rule in self.rules:
-                    mtch = rule.pattern.match(line, position)
+                    _line = line
+                    mtch, _token = rule.match(_line, position, lineno)
                     if mtch:
-                        token = Token(
-                            identifier=rule.identifier, content=mtch.group(), position=position, lineno=lineno)
-
+                        token = _token
                         lexing.emit_matched_token(token=token)
 
                         position = mtch.end()

--- a/lexery/__init__.py
+++ b/lexery/__init__.py
@@ -12,6 +12,7 @@ __status__ = 'Production'
 
 class Token:
     """Represent a token of a text."""
+
     def __init__(self, identifier: str = '', content: str = '', position: int = -1, lineno: int = -1) -> None:
         """
         Initialize.
@@ -41,6 +42,7 @@ class Token:
 
 class Rule:
     """Define a lexing rule."""
+
     def __init__(self, identifier: str, pattern: Pattern, next_rule=None) -> None:
         """
         Initialize.
@@ -82,6 +84,7 @@ NONTAB_RE = re.compile(r'[^\t]')
 
 class Error(Exception):
     """Is raised when no token rule applies."""
+
     def __init__(self, line: str, position: int, lineno: int) -> None:
         """
         Initialize.
@@ -108,6 +111,7 @@ WHITESPACE_RE = re.compile(r'\s')
 
 class _Lexing:
     """Keep state of a single lexing."""
+
     def __init__(self, unmatched_identifier: Optional[str] = None) -> None:
         """
         Initialize.
@@ -129,10 +133,11 @@ class _Lexing:
             assert self.unmatched_identifier is not None
 
             self.tokens[-1].append(
-                Token(identifier=self.unmatched_identifier,
-                      content=''.join(self._unmatched_accumulator),
-                      position=self._unmatched_pos,
-                      lineno=self._unmatched_lineno))
+                Token(
+                    identifier=self.unmatched_identifier,
+                    content=''.join(self._unmatched_accumulator),
+                    position=self._unmatched_pos,
+                    lineno=self._unmatched_lineno))
 
             self._unmatched_accumulator = []
 
@@ -144,10 +149,11 @@ class _Lexing:
             assert self.unmatched_identifier is not None
 
             self.tokens[-1].append(
-                Token(identifier=self.unmatched_identifier,
-                      content=''.join(self._unmatched_accumulator),
-                      position=self._unmatched_pos,
-                      lineno=self._unmatched_lineno))
+                Token(
+                    identifier=self.unmatched_identifier,
+                    content=''.join(self._unmatched_accumulator),
+                    position=self._unmatched_pos,
+                    lineno=self._unmatched_lineno))
 
             self._unmatched_accumulator = []
 
@@ -167,19 +173,19 @@ class _Lexing:
             assert self.unmatched_identifier is not None
 
             self.tokens[-1].append(
-                Token(identifier=self.unmatched_identifier,
-                      content=''.join(self._unmatched_accumulator),
-                      position=self._unmatched_pos,
-                      lineno=self._unmatched_lineno))
+                Token(
+                    identifier=self.unmatched_identifier,
+                    content=''.join(self._unmatched_accumulator),
+                    position=self._unmatched_pos,
+                    lineno=self._unmatched_lineno))
 
             self._unmatched_accumulator = []
 
 
 class Lexer:
     """Lex the text given the rules table."""
-    def __init__(self,
-                 rules: List[Rule],
-                 skip_whitespace: bool = False,
+
+    def __init__(self, rules: List[Rule], skip_whitespace: bool = False,
                  unmatched_identifier: Optional[str] = None) -> None:
         """
         Initialize.

--- a/lexery/__init__.py
+++ b/lexery/__init__.py
@@ -60,10 +60,10 @@ class Rule:
         if self.next is not None and mtch is not None:
             pos = 0
             for r in self.next:
-                _mtch, _t = r.match(mtch.group(), pos, 0)
-                if _mtch:
-                    ret.append(_t)
-                    pos += len(_mtch.group())
+                another_mtch, another_t = r.match(mtch.group(), pos, 0)
+                if another_mtch:
+                    ret.append(another_t)
+                    pos += len(another_mtch.group())
         else:
             if mtch:
                 ret = mtch.group()

--- a/precommit.py
+++ b/precommit.py
@@ -11,10 +11,11 @@ def main() -> int:
     Main routine
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--overwrite",
-                        help="Overwrites the unformatted source files with the well-formatted code in place. "
-                        "If not set, an exception is raised if any of the files do not conform to the style guide.",
-                        action='store_true')
+    parser.add_argument(
+        "--overwrite",
+        help="Overwrites the unformatted source files with the well-formatted code in place. "
+        "If not set, an exception is raised if any of the files do not conform to the style guide.",
+        action='store_true')
 
     args = parser.parse_args()
 
@@ -39,16 +40,16 @@ def main() -> int:
     subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "lexery"], cwd=str(repo_root))
 
     print("Pydocstyle'ing...")
-    subprocess.check_call(["pydocstyle", "lexery", "--ignore=D203,D204,D212"], cwd=str(repo_root))
+    subprocess.check_call(["pydocstyle", "lexery"], cwd=str(repo_root))
 
     print("Doctest'ing ...")
     subprocess.check_call([sys.executable, '-m', 'doctest', 'README.rst'])
-    subprocess.check_call([sys.executable, '-m', 'doctest'] +
-                          [str(pth) for pth in pathlib.Path("lexery").glob("**/*.py")])
+    subprocess.check_call(
+        [sys.executable, '-m', 'doctest'] + [str(pth) for pth in pathlib.Path("lexery").glob("**/*.py")])
 
     print("Testing...")
-    subprocess.check_call(["coverage", "run", "--source", "lexery", "-m", "unittest", "discover", "tests"],
-                          cwd=str(repo_root))
+    subprocess.check_call(
+        ["coverage", "run", "--source", "lexery", "-m", "unittest", "discover", "tests"], cwd=str(repo_root))
 
     subprocess.check_call(["coverage", "report"])
 

--- a/precommit.py
+++ b/precommit.py
@@ -11,11 +11,10 @@ def main() -> int:
     Main routine
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--overwrite",
-        help="Overwrites the unformatted source files with the well-formatted code in place. "
-        "If not set, an exception is raised if any of the files do not conform to the style guide.",
-        action='store_true')
+    parser.add_argument("--overwrite",
+                        help="Overwrites the unformatted source files with the well-formatted code in place. "
+                        "If not set, an exception is raised if any of the files do not conform to the style guide.",
+                        action='store_true')
 
     args = parser.parse_args()
 
@@ -40,16 +39,16 @@ def main() -> int:
     subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "lexery"], cwd=str(repo_root))
 
     print("Pydocstyle'ing...")
-    subprocess.check_call(["pydocstyle", "lexery"], cwd=str(repo_root))
+    subprocess.check_call(["pydocstyle", "lexery", "--ignore=D203,D204,D212"], cwd=str(repo_root))
 
     print("Doctest'ing ...")
     subprocess.check_call([sys.executable, '-m', 'doctest', 'README.rst'])
-    subprocess.check_call(
-        [sys.executable, '-m', 'doctest'] + [str(pth) for pth in pathlib.Path("lexery").glob("**/*.py")])
+    subprocess.check_call([sys.executable, '-m', 'doctest'] +
+                          [str(pth) for pth in pathlib.Path("lexery").glob("**/*.py")])
 
     print("Testing...")
-    subprocess.check_call(
-        ["coverage", "run", "--source", "lexery", "-m", "unittest", "discover", "tests"], cwd=str(repo_root))
+    subprocess.check_call(["coverage", "run", "--source", "lexery", "-m", "unittest", "discover", "tests"],
+                          cwd=str(repo_root))
 
     subprocess.check_call(["coverage", "report"])
 

--- a/tests/test_lexery.py
+++ b/tests/test_lexery.py
@@ -44,32 +44,32 @@ class TestLexery(unittest.TestCase):
             lexery.Token('rpar', ')', 22, 0),
             lexery.Token('space', ' ', 23, 0),
             lexery.Token('semi', ';', 24, 0)
-        ], [],
-                    [
-                        lexery.Token('identifier', 'resize', 0, 2),
-                        lexery.Token('lpar', '(', 6, 2),
-                        lexery.Token('number', '40', 7, 2),
-                        lexery.Token('comma', ',', 9, 2),
-                        lexery.Token('space', ' ', 10, 2),
-                        lexery.Token('number', '10', 11, 2),
-                        lexery.Token('rpar', ')', 13, 2),
-                        lexery.Token('semi', ';', 14, 2)
-                    ]]
+        ], [], [
+            lexery.Token('identifier', 'resize', 0, 2),
+            lexery.Token('lpar', '(', 6, 2),
+            lexery.Token('number', '40', 7, 2),
+            lexery.Token('comma', ',', 9, 2),
+            lexery.Token('space', ' ', 10, 2),
+            lexery.Token('number', '10', 11, 2),
+            lexery.Token('rpar', ')', 13, 2),
+            lexery.Token('semi', ';', 14, 2)
+        ]]
 
         self.assertEqual(expected, tokens)
 
     def test_skip_whitespace(self):
         text = 'crop \t   ( 20, 30, 40, 10 ) ;'
 
-        lexer = lexery.Lexer(rules=[
-            lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
-            lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
-            lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
-            lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
-            lexery.Rule(identifier='comma', pattern=re.compile(r',')),
-            lexery.Rule(identifier='semi', pattern=re.compile(r';'))
-        ],
-                             skip_whitespace=True)
+        lexer = lexery.Lexer(
+            rules=[
+                lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
+                lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
+                lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
+                lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
+                lexery.Rule(identifier='comma', pattern=re.compile(r',')),
+                lexery.Rule(identifier='semi', pattern=re.compile(r';'))
+            ],
+            skip_whitespace=True)
 
         tokens = lexer.lex(text=text)
 
@@ -92,16 +92,17 @@ class TestLexery(unittest.TestCase):
     def test_unmatched_identifier(self):
         text = 'crop {} ( 20, 30, 40, 10 ) ; {}\n{}'
 
-        lexer = lexery.Lexer(rules=[
-            lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
-            lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
-            lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
-            lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
-            lexery.Rule(identifier='comma', pattern=re.compile(r',')),
-            lexery.Rule(identifier='semi', pattern=re.compile(r';')),
-            lexery.Rule(identifier='space', pattern=re.compile(r' '))
-        ],
-                             unmatched_identifier="unmatched")
+        lexer = lexery.Lexer(
+            rules=[
+                lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
+                lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
+                lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
+                lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
+                lexery.Rule(identifier='comma', pattern=re.compile(r',')),
+                lexery.Rule(identifier='semi', pattern=re.compile(r';')),
+                lexery.Rule(identifier='space', pattern=re.compile(r' '))
+            ],
+            unmatched_identifier="unmatched")
 
         tokens = lexer.lex(text=text)
 

--- a/tests/test_lexery.py
+++ b/tests/test_lexery.py
@@ -44,32 +44,32 @@ class TestLexery(unittest.TestCase):
             lexery.Token('rpar', ')', 22, 0),
             lexery.Token('space', ' ', 23, 0),
             lexery.Token('semi', ';', 24, 0)
-        ], [], [
-            lexery.Token('identifier', 'resize', 0, 2),
-            lexery.Token('lpar', '(', 6, 2),
-            lexery.Token('number', '40', 7, 2),
-            lexery.Token('comma', ',', 9, 2),
-            lexery.Token('space', ' ', 10, 2),
-            lexery.Token('number', '10', 11, 2),
-            lexery.Token('rpar', ')', 13, 2),
-            lexery.Token('semi', ';', 14, 2)
-        ]]
+        ], [],
+                    [
+                        lexery.Token('identifier', 'resize', 0, 2),
+                        lexery.Token('lpar', '(', 6, 2),
+                        lexery.Token('number', '40', 7, 2),
+                        lexery.Token('comma', ',', 9, 2),
+                        lexery.Token('space', ' ', 10, 2),
+                        lexery.Token('number', '10', 11, 2),
+                        lexery.Token('rpar', ')', 13, 2),
+                        lexery.Token('semi', ';', 14, 2)
+                    ]]
 
         self.assertEqual(expected, tokens)
 
     def test_skip_whitespace(self):
         text = 'crop \t   ( 20, 30, 40, 10 ) ;'
 
-        lexer = lexery.Lexer(
-            rules=[
-                lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
-                lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
-                lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
-                lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
-                lexery.Rule(identifier='comma', pattern=re.compile(r',')),
-                lexery.Rule(identifier='semi', pattern=re.compile(r';'))
-            ],
-            skip_whitespace=True)
+        lexer = lexery.Lexer(rules=[
+            lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
+            lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
+            lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
+            lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
+            lexery.Rule(identifier='comma', pattern=re.compile(r',')),
+            lexery.Rule(identifier='semi', pattern=re.compile(r';'))
+        ],
+                             skip_whitespace=True)
 
         tokens = lexer.lex(text=text)
 
@@ -92,17 +92,16 @@ class TestLexery(unittest.TestCase):
     def test_unmatched_identifier(self):
         text = 'crop {} ( 20, 30, 40, 10 ) ; {}\n{}'
 
-        lexer = lexery.Lexer(
-            rules=[
-                lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
-                lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
-                lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
-                lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
-                lexery.Rule(identifier='comma', pattern=re.compile(r',')),
-                lexery.Rule(identifier='semi', pattern=re.compile(r';')),
-                lexery.Rule(identifier='space', pattern=re.compile(r' '))
-            ],
-            unmatched_identifier="unmatched")
+        lexer = lexery.Lexer(rules=[
+            lexery.Rule(identifier='identifier', pattern=re.compile(r'[a-zA-Z_][a-zA-Z_]*')),
+            lexery.Rule(identifier='lpar', pattern=re.compile(r'\(')),
+            lexery.Rule(identifier='number', pattern=re.compile(r'[1-9][0-9]*')),
+            lexery.Rule(identifier='rpar', pattern=re.compile(r'\)')),
+            lexery.Rule(identifier='comma', pattern=re.compile(r',')),
+            lexery.Rule(identifier='semi', pattern=re.compile(r';')),
+            lexery.Rule(identifier='space', pattern=re.compile(r' '))
+        ],
+                             unmatched_identifier="unmatched")
 
         tokens = lexer.lex(text=text)
 


### PR DESCRIPTION
We add support for recursive rules.

For example:
```python
import re
from lexer import Lexer, Rule

text = 'a b(ac) c'
lexer = Lexer(rules=[Rule('a', re.compile('a\s*')),
                     Rule('b', re.compile('b\(\w+\)\s*'), next=[
                         Rule('clause', re.compile('b\(')),
                         Rule('obj', re.compile('\w+')),
                         Rule(')', re.compile('\)')),
                         ]),
                     Rule('c', re.compile('c')),
                     ])
t = lexer.lex(text)
```

This code will give you:
```
[
    Token('a', 'a', 0, 0),
    Token(
        'b',
        [
            Token('clause', 'b(', 0, 0),
            Token('obj', 'ac', 2, 0),
            Token(')', ')', 4, 0)
        ],
        5, 0
    ),
    Token('c', 'c', 7, 0)
]
```
