### PR TITLE
Update Python, mypy and pylint versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@master

--- a/lexery/__init__.py
+++ b/lexery/__init__.py
@@ -77,7 +77,7 @@ class Error(Exception):
     def __str__(self) -> str:
         """Represent the error with a nice pointer as a multi-line message."""
         pointer = re.sub(NONTAB_RE, ' ', self.line[:self.position]) + '^'
-        txt = (f'Unmatched text at line {self.lineno} and position {self.position}:\n' f'{self.line}\n' f'{pointer}')
+        txt = f'Unmatched text at line {self.lineno} and position {self.position}:\n{self.line}\n{pointer}'
         return txt
 
 

--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace
+disable=too-few-public-methods,len-as-condition
 

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,14 @@ setup(
     author_email='marko@ristin.ch',
     # yapf: disable
     classifiers=[
-        'Development Status :: 5 - Production/Stable', 'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License', 'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8', 'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10'
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     # yapf: enable
     keywords='lexer regexp regular expression',
@@ -35,7 +38,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=[],
     extras_require={
-        'dev': ['mypy==0.942', 'pylint==2.13.4', 'yapf==0.20.2', 'coverage>=4.5.1,<5', 'pydocstyle==6.1.1']
+        'dev': ['mypy==1.2.0', 'pylint==2.17.2', 'yapf==0.20.2', 'coverage>=4.5.1,<5', 'pydocstyle==6.1.1']
     },
     py_modules=['lexery'],
     package_data={"lexery": ["py.typed"]})


### PR DESCRIPTION
We remove support for Python 3.6 since it reached EOL. In addition, we add support for Python 3.11, and update mypy and pylint to latest versions.